### PR TITLE
Abort if we are making a code change

### DIFF
--- a/checkdiff/checkdiff.sh
+++ b/checkdiff/checkdiff.sh
@@ -21,6 +21,11 @@ SKADHOOK=/home/regalstreak2/android/skadhook
 SKADOOSH=$SKADHOOK/skadoosh
 DIFF=$SKADHOOK/checkdiff
 
+# Check if we don't want to trigger a build
+if [ grep "DONTBUILD" "$SKADOOSH/compress.bash" ] || [ grep "DONTBUILD" "$SKADOOSH/skadoo.sh" ]; then
+  exit 1
+fi
+
 # Copy new file to current
 rm -rf $DIFF/compress-new
 cp $SKADOOSH/compress.bash $DIFF/compress-new


### PR DESCRIPTION
Adding `DONTBUILD` to any of the bash scripts will abort the `checkdiff` operation and terminate compression. Will be insanely helpful when making code changes that don't need the current ROM to be re-compressed.
